### PR TITLE
Adding prod.exs to dead_letter for successful build

### DIFF
--- a/apps/dead_letter/config/prod.exs
+++ b/apps/dead_letter/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config


### PR DESCRIPTION
Build currently failing because the prod environment for dead_letter doesn't have a prod.exs; adding a basic one.