### PR TITLE
Make CI faster please

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,17 @@ otp_release:
   - '21.3'
 services:
   - docker
+cache:
+  directories:
+    - deps
+    - _build/dev
+    - _build/test
+    - _build/integration
+before_cache:
+  - bash scripts/travis-uncache.sh
 jobs:
   include:
-    - name: verify
+    - name: static analysis
       script: bash scripts/travis-verify.sh
     - name: unit test
       script: mix test
@@ -15,14 +23,14 @@ jobs:
       script: bash scripts/travis-test.sh pipeline
     - name: dead_letter
       script: bash scripts/travis-test.sh dead_letter
+    - name: e2e
+      script: bash scripts/travis-test.sh e2e
     - name: andi
       script: bash scripts/travis-test.sh andi
     - name: flair
       script: bash scripts/travis-test.sh flair
     - name: forklift
       script: bash scripts/travis-test.sh forklift
-    - name: e2e
-      script: bash scripts/travis-test.sh e2e
 deploy:
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,24 @@ otp_release:
   - '21.3'
 services:
   - docker
-env:
-  - DOCKER_COMPOSE_VERSION=1.23.1
-script:
-  - bash scripts/travis-build.sh
-deploy:
+jobs:
+  include:
+    - name: verify
+      script: bash scripts/travis-verify.sh
+    - name: unit test
+      script: mix test
+    - name: pipeline
+      script: bash scripts/travis-test.sh pipeline
+    - name: dead_letter
+      script: bash scripts/travis-test.sh dead_letter
+    - name: andi
+      script: bash scripts/travis-test.sh andi
+    - name: flair
+      script: bash scripts/travis-test.sh flair
+    - name: forklift
+      script: bash scripts/travis-test.sh forklift
+    - name: e2e
+      script: bash scripts/travis-test.sh e2e
 deploy:
   - provider: script
     skip_cleanup: true

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -14,7 +14,8 @@ defmodule Andi.MixProject do
       test_paths: Mix.env() |> test_paths(),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      aliases: aliases()
     ]
   end
 
@@ -58,5 +59,9 @@ defmodule Andi.MixProject do
       {:distillery, "~> 2.1"},
       {:tasks, in_umbrella: true, only: :dev}
     ]
+  end
+
+  defp aliases do
+    [verify: ["format --check-formatted", "credo", "sobelow -i Config.HTTPS --skip --compact --exit low"]]
   end
 end

--- a/apps/dead_letter/mix.exs
+++ b/apps/dead_letter/mix.exs
@@ -14,6 +14,7 @@ defmodule DeadLetter.MixProject do
       test_paths: Mix.env() |> test_paths(),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      aliases: aliases(),
       docs: docs(),
       description: description(),
       package: package()
@@ -39,6 +40,10 @@ defmodule DeadLetter.MixProject do
       {:assertions, "~> 0.14", only: [:test, :integration]},
       {:tasks, in_umbrella: true, only: :dev}
     ]
+  end
+
+  defp aliases do
+    [verify: ["format --check-formatted", "credo"]]
   end
 
   defp elixirc_paths(env) when env in [:test, :integration], do: ["lib", "test/support"]

--- a/apps/e2e/config/config.exs
+++ b/apps/e2e/config/config.exs
@@ -2,5 +2,5 @@ use Mix.Config
 
 config :e2e,
   divo: "test/docker-compose.yml",
-  divo_wait: [dwell: 700, max_tries: 50],
+  divo_wait: [dwell: 1_000, max_tries: 120],
   elsa_brokers: [{:localhost, 9092}]

--- a/apps/e2e/mix.exs
+++ b/apps/e2e/mix.exs
@@ -32,7 +32,10 @@ defmodule E2E.MixProject do
   end
 
   defp aliases do
-    [verify: ["format --check-formatted"]]
+    [
+      verify: "format --check-formatted",
+      "test.integration": "test.integration --include e2e"
+    ]
   end
 
   defp test_paths(:integration), do: ["test"]

--- a/apps/e2e/mix.exs
+++ b/apps/e2e/mix.exs
@@ -12,6 +12,7 @@ defmodule E2E.MixProject do
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      aliases: aliases(),
       test_paths: Mix.env() |> test_paths()
     ]
   end
@@ -28,6 +29,10 @@ defmodule E2E.MixProject do
       {:forklift, in_umbrella: true},
       {:divo, "~> 1.1", only: [:dev, :test, :integration]}
     ]
+  end
+
+  defp aliases do
+    [verify: ["format --check-formatted"]]
   end
 
   defp test_paths(:integration), do: ["test"]

--- a/apps/e2e/test/test_helper.exs
+++ b/apps/e2e/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start(exclude: [:e2e])
+ExUnit.start(exclude: [:e2e], seed: 0)

--- a/apps/flair/mix.exs
+++ b/apps/flair/mix.exs
@@ -61,7 +61,8 @@ defmodule Flair.MixProject do
 
   defp aliases do
     [
-      test: ["test --no-start"]
+      test: ["test --no-start"],
+      verify: ["format --check-formatted", "credo"]
     ]
   end
 

--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -12,6 +12,7 @@ defmodule Forklift.MixProject do
       lockfile: "../../mix.lock",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      aliases: aliases(),
       docs: docs(),
       elixirc_paths: elixirc_paths(Mix.env()),
       test_paths: test_paths(Mix.env())
@@ -59,6 +60,10 @@ defmodule Forklift.MixProject do
       {:pipeline, in_umbrella: true},
       {:mox, "~> 0.5.1", only: [:dev, :test, :integration]}
     ]
+  end
+
+  defp aliases do
+    [verify: ["format --check-formatted", "credo"]]
   end
 
   defp docs do

--- a/apps/pipeline/mix.exs
+++ b/apps/pipeline/mix.exs
@@ -12,7 +12,8 @@ defmodule Pipeline.MixProject do
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       test_paths: Mix.env() |> test_paths(),
-      deps: deps()
+      deps: deps(),
+      aliases: aliases()
     ]
   end
 
@@ -35,6 +36,10 @@ defmodule Pipeline.MixProject do
       {:divo, "~> 1.1", only: [:dev, :integration]},
       {:divo_kafka, "~> 0.1.5", only: [:dev, :integration]}
     ]
+  end
+
+  defp aliases do
+    [verify: "format --check-formatted"]
   end
 
   defp test_paths(:integration), do: ["test/integration"]

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Smartcitiesdata.MixProject do
   defp aliases do
     [
       test: "cmd mix test --color",
-      "test.e2e": "cmd --app e2e mix test.integration --seed 0 --color --include e2e",
+      "test.e2e": "cmd --app e2e mix test.integration --color --include e2e",
       sobelow: "cmd --app andi mix sobelow -i Config.HTTPS --skip --compact --exit low"
     ]
   end

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
+DOCKER_COMPOSE_VERSION=1.23.1
+
+app="$1"
+
 # before_install
 sudo rm /usr/local/bin/docker-compose
 curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
@@ -8,15 +12,6 @@ chmod +x docker-compose
 sudo mv docker-compose /usr/local/bin
 sudo service postgresql stop
 
-# install
-mix local.rebar --force
-mix local.hex --force
-mix deps.get
-mix hex.outdated || true
-
 # script
-mix test
-mix format --check-formatted
-mix credo
-mix sobelow
+cd apps/$app
 mix test.integration

--- a/scripts/travis-uncache.sh
+++ b/scripts/travis-uncache.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+apps=$(find apps -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+
+for app in ${apps[*]}; do
+    rm -rf _build/{dev,test,integration}/lib/$app/
+done

--- a/scripts/travis-verify.sh
+++ b/scripts/travis-verify.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mix format --check-formatted
+mix credo
+mix sobelow


### PR DESCRIPTION
PR builds should now run in under 8 minutes. Does it by running a bunch of the build steps in parallel, while caching compiled dependencies.

Most of our current time is now spent pulling Docker images, which can't be optimized any further from what I can tell.