### PR TITLE
Adding custom mime types to the umbrella

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,3 +18,8 @@ import_config "../apps/*/config/config.exs"
 #       level: :info,
 #       format: "$date $time [$level] $metadata$message\n",
 #       metadata: [:user_id]
+
+config :mime, :types, %{
+  "application/gtfs+protobuf" => ["gtfs"],
+  "application/vnd.ogc.wms_xml" => ["wms"]
+}


### PR DESCRIPTION
Mime allows you to define custom types and we currently support two that have not been adopted as a "formal standard". When mime can't find a valid type it uses the standard default of "application/octet-stream" and andi is currently encoding dataset updates for gtfs (cota) with this default value that is invalid from the perspective of our system.

Since "application/octet-stream" is a valid mime type and once andi has encoded dataset updates with that and lost the original input ("gtfs") reaper and other downstream apps will blow up without this fix.