### PR TITLE
Adding a sleep to restrict startup tasks from running in a tight loop

### DIFF
--- a/apps/forklift/lib/forklift/init.ex
+++ b/apps/forklift/lib/forklift/init.ex
@@ -18,7 +18,10 @@ defmodule Forklift.Init do
 
     Forklift.Datasets.get_all!()
     |> Enum.map(&reader_init_args/1)
-    |> Enum.each(fn args -> @reader.init(args) end)
+    |> Enum.each(fn args ->
+      @reader.init(args)
+      Process.sleep(250)
+    end)
   end
 
   defp reader_init_args(dataset) do

--- a/apps/forklift/test/unit/integration/init_test.exs
+++ b/apps/forklift/test/unit/integration/init_test.exs
@@ -25,8 +25,8 @@ defmodule Forklift.Integration.InitTest do
     allow Brook.get_all_values!(instance_name(), :datasets), return: [dataset1, dataset2]
     assert {:ok, _} = Forklift.Init.start_link([])
 
-    assert_receive %SmartCity.Dataset{id: "view-state-1"}
-    assert_receive %SmartCity.Dataset{id: "view-state-2"}
+    assert_receive(%SmartCity.Dataset{id: "view-state-1"}, 1000)
+    assert_receive(%SmartCity.Dataset{id: "view-state-2"}, 1000)
   end
 
   test "initializes output_topic TopicWriter" do


### PR DESCRIPTION
smartcitiesdata #248