### PR TITLE
Forklift.Init monitors Pipeline.DynamicSupervisor

### DIFF
--- a/apps/forklift/lib/forklift/application.ex
+++ b/apps/forklift/lib/forklift/application.ex
@@ -16,7 +16,7 @@ defmodule Forklift.Application do
         Forklift.Quantum.Scheduler,
         {Brook, Application.get_env(:forklift, :brook)},
         {DeadLetter, Application.get_env(:forklift, :dead_letter)},
-        Forklift.Init
+        Forklift.InitServer
       ]
       |> List.flatten()
 

--- a/apps/forklift/lib/forklift/data_writer.ex
+++ b/apps/forklift/lib/forklift/data_writer.ex
@@ -65,7 +65,7 @@ defmodule Forklift.DataWriter do
         :ok
 
       topic ->
-        bootstrap_args(:forklift, topic)
+        bootstrap_args(topic)
         |> @topic_writer.init()
     end
   end
@@ -157,14 +157,14 @@ defmodule Forklift.DataWriter do
     |> Forklift.Util.remove_from_metadata(:forklift_start_time)
   end
 
-  defp bootstrap_args(instance, topic) do
+  defp bootstrap_args(topic) do
     [
-      instance: instance,
-      endpoints: Application.get_env(instance, :elsa_brokers),
+      instance: instance_name(),
+      endpoints: Application.get_env(:forklift, :elsa_brokers),
       topic: topic,
-      producer_name: Application.get_env(instance, :producer_name),
-      retry_count: Application.get_env(instance, :retry_count),
-      retry_delay: Application.get_env(instance, :retry_initial_delay)
+      producer_name: Application.get_env(:forklift, :producer_name),
+      retry_count: Application.get_env(:forklift, :retry_count),
+      retry_delay: Application.get_env(:forklift, :retry_initial_delay)
     ]
   end
 end

--- a/apps/forklift/lib/forklift/init_server.ex
+++ b/apps/forklift/lib/forklift/init_server.ex
@@ -1,4 +1,4 @@
-defmodule Forklift.Init do
+defmodule Forklift.InitServer do
   @moduledoc """
   Task to initialize forklift and start ingesting each previously recorded dataset
   """
@@ -6,11 +6,10 @@ defmodule Forklift.Init do
 
   alias Forklift.MessageHandler
 
-  @name :forklift_init_server
   @reader Application.get_env(:forklift, :data_reader)
 
   def start_link(opts) do
-    name = Keyword.get(opts, :name, @name)
+    name = Keyword.get(opts, :name, __MODULE__)
     GenServer.start_link(__MODULE__, [], name: name)
   end
 
@@ -23,7 +22,7 @@ defmodule Forklift.Init do
     end
   end
 
-  def handle_info({:DOWN, _, _, down, _}, %{pipeline: pid}) when pid == down do
+  def handle_info({:DOWN, _, _, pid, _}, %{pipeline: pid}) do
     :ok = init_readers()
     {:noreply, %{pipeline: Process.whereis(Pipeline.DynamicSupervisor)}}
   end

--- a/apps/forklift/test/unit/integration/init_server_test.exs
+++ b/apps/forklift/test/unit/integration/init_server_test.exs
@@ -1,4 +1,4 @@
-defmodule Forklift.Integration.InitTest do
+defmodule Forklift.Integration.InitServerTest do
   use ExUnit.Case
   use Placebo
 
@@ -23,7 +23,7 @@ defmodule Forklift.Integration.InitTest do
     stub(MockTopic, :init, fn _ -> :ok end)
     stub(MockReader, :init, fn args -> send(test, args[:dataset]) && :ok end)
 
-    assert {:ok, _} = Forklift.Init.start_link(name: :foo)
+    assert {:ok, _} = Forklift.InitServer.start_link(name: :foo)
 
     assert_receive %SmartCity.Dataset{id: "view-state-1"}, 1000
     assert_receive %SmartCity.Dataset{id: "view-state-2"}, 1000
@@ -36,7 +36,7 @@ defmodule Forklift.Integration.InitTest do
     stub(MockReader, :init, fn _ -> :ok end)
     stub(MockTopic, :init, fn args -> send(test, args[:topic]) && :ok end)
 
-    assert {:ok, _} = Forklift.Init.start_link(name: :bar)
+    assert {:ok, _} = Forklift.InitServer.start_link(name: :bar)
     assert_receive "test-topic"
   end
 
@@ -51,7 +51,7 @@ defmodule Forklift.Integration.InitTest do
     expect(MockReader, :init, 2, fn _ -> :ok end)
     expect(MockReader, :init, 2, fn args -> send(test, args[:dataset]) && :ok end)
 
-    Forklift.Init.start_link(name: :baz)
+    Forklift.InitServer.start_link(name: :baz)
     DynamicSupervisor.stop(Pipeline.DynamicSupervisor, :test)
 
     assert_receive dataset1, 1_000

--- a/apps/forklift/test/unit/integration/init_test.exs
+++ b/apps/forklift/test/unit/integration/init_test.exs
@@ -16,26 +16,45 @@ defmodule Forklift.Integration.InitTest do
 
   test "starts a dataset topic reader for each dataset view state" do
     test = self()
-    expect(MockReader, :init, 2, fn args -> send(test, args[:dataset]) && :ok end)
-    expect(MockTopic, :init, fn _ -> :ok end)
-
     dataset1 = TDG.create_dataset(%{id: "view-state-1"})
     dataset2 = TDG.create_dataset(%{id: "view-state-2"})
 
     allow Brook.get_all_values!(instance_name(), :datasets), return: [dataset1, dataset2]
+    stub(MockTopic, :init, fn _ -> :ok end)
+    stub(MockReader, :init, fn args -> send(test, args[:dataset]) && :ok end)
+
     assert {:ok, _} = Forklift.Init.start_link(name: :foo)
 
-    assert_receive(%SmartCity.Dataset{id: "view-state-1"}, 1000)
-    assert_receive(%SmartCity.Dataset{id: "view-state-2"}, 1000)
+    assert_receive %SmartCity.Dataset{id: "view-state-1"}, 1000
+    assert_receive %SmartCity.Dataset{id: "view-state-2"}, 1000
   end
 
   test "initializes output_topic TopicWriter" do
     test = self()
-    expect(MockReader, :init, 0, fn _ -> :ok end)
-    expect(MockTopic, :init, fn args -> send(test, args[:topic]) && :ok end)
+
     allow Brook.get_all_values!(instance_name(), :datasets), return: []
+    stub(MockReader, :init, fn _ -> :ok end)
+    stub(MockTopic, :init, fn args -> send(test, args[:topic]) && :ok end)
 
     assert {:ok, _} = Forklift.Init.start_link(name: :bar)
     assert_receive "test-topic"
+  end
+
+  test "re-initializes if Pipeline.DynamicSupervisor crashes" do
+    test = self()
+    dataset1 = TDG.create_dataset(%{id: "restart-1"})
+    dataset2 = TDG.create_dataset(%{id: "restart-2"})
+
+    allow Brook.get_all_values!(instance_name(), :datasets), return: [dataset1, dataset2]
+    stub(MockTopic, :init, fn _ -> :ok end)
+
+    expect(MockReader, :init, 2, fn _ -> :ok end)
+    expect(MockReader, :init, 2, fn args -> send(test, args[:dataset]) && :ok end)
+
+    Forklift.Init.start_link(name: :baz)
+    DynamicSupervisor.stop(Pipeline.DynamicSupervisor, :test)
+
+    assert_receive dataset1, 1_000
+    assert_receive dataset2, 1_000
   end
 end


### PR DESCRIPTION
If `Pipeline.DynamicSupervisor` were to crash, Forklift would never re-init its dataset topic readers. This PR refactors `Forklift.Init` into a GenServer and monitors the DynamicSupervisor. On crash, `Forklift.Init` will re-init those readers.