### PR TITLE
Bump forklift to v0.10.0

### DIFF
--- a/apps/forklift/mix.exs
+++ b/apps/forklift/mix.exs
@@ -4,7 +4,7 @@ defmodule Forklift.MixProject do
   def project do
     [
       app: :forklift,
-      version: "0.9.1",
+      version: "0.10.0",
       elixir: "~> 1.8",
       build_path: "../../_build",
       config_path: "../../config/config.exs",


### PR DESCRIPTION
Fixing the Forklift version issue by jumping to `v0.10.0` to ease any potential confusion.