### PR TITLE
Tag version and Mix version must match

### DIFF
--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -71,6 +71,7 @@ defmodule Reaper.MixProject do
       {:yeet, "~> 1.0"},
       # Test/Dev Dependencies
       {:benchee, "~> 1.0", only: [:integration]},
+      {:tasks, in_umbrella: true, only: :dev},
       {:bypass, "~> 1.0", only: [:test, :integration]},
       {:checkov, "~> 0.4", only: [:test, :integration]},
       {:credo, "~> 1.1", only: [:dev, :test, :integration], runtime: false},

--- a/apps/valkyrie/mix.exs
+++ b/apps/valkyrie/mix.exs
@@ -43,6 +43,7 @@ defmodule Valkyrie.MixProject do
       {:divo_kafka, "~> 0.1", only: [:integration]},
       {:divo_redis, "~> 0.1", only: [:integration]},
       {:excoveralls, "~> 0.11.1", only: :test},
+      {:tasks, in_umbrella: true, only: :dev},
       {:jason, "~> 1.1"},
       {:libcluster, "~> 3.1"},
       {:mix_test_watch, "~> 0.9", only: :dev, runtime: false},

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -5,6 +5,12 @@ set -e
 if [ ! -z "$TRAVIS_TAG" ]; then
     app=$(echo "$TRAVIS_TAG" | cut -d@ -f1)
     vsn=$(echo "$TRAVIS_TAG" | cut -d@ -f2)
+    mix_vsn=$(mix cmd --app $app mix app.version | tail -1)
+
+    if [ ! $vsn = $mix_vsn ]; then
+        echo "Tag version '$vsn' does not match mix version '$mix_vsn'"
+        exit 1
+    fi
 
     echo "Building smartcitiesdata/${app:?COULD NOT DETERMINE APP}:${vsn:?COULD NOT DETERMINE VERSION}"
 


### PR DESCRIPTION
Adds the `app.version` mix task to reaper and valkyrie. Forces mix version and tag version to match before a release's Docker image can be built.