### PR TITLE
Fix character encoding

### DIFF
--- a/apps/reaper/lib/reaper/xml/xml_stream/sax_handler.ex
+++ b/apps/reaper/lib/reaper/xml/xml_stream/sax_handler.ex
@@ -91,7 +91,7 @@ defmodule XMLStream.SaxHandler do
   def handle_event(:characters, chars, %State{stack: stack, accumulate: true} = state) do
     [{tag_name, attributes, content} | stack] = stack
 
-    current = {tag_name, attributes, [chars | content]}
+    current = {tag_name, attributes, [{:characters, chars} | content]}
 
     state
     |> State.update(stack: [current | stack])

--- a/apps/reaper/test/support/test_data/repeat.xml
+++ b/apps/reaper/test/support/test_data/repeat.xml
@@ -2,15 +2,19 @@
   <row>
     <row _id="a">
       <coredata_id>1234</coredata_id>
+      <escape_me><![CDATA[ One & Two]]></escape_me>
     </row>
     <row _id="b">
       <coredata_id>2345</coredata_id>
+      <escape_me><![CDATA[ One & Two]]></escape_me>
     </row>
     <row _id="c">
       <coredata_id>3456</coredata_id>
+      <escape_me><![CDATA[ One & Two]]></escape_me>
     </row>
     <row _id="d">
       <coredata_id>4567</coredata_id>
+      <escape_me>One &amp; Two></escape_me>
     </row>
   </row>
 </response>


### PR DESCRIPTION
Just emitting the characters as text caused a downstream problem when
ampersands were passed on. By tagging the in a {:characters, chars}
tuple, we instruct the Saxy encoder to escape this for us. They are
converted back to normal text by calling SweetXml.xpath/2.

I will write a test for this case before merging.