### PR TITLE
Add a workflow to check app version for Pull Requests

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,0 +1,31 @@
+name: VersionChecker
+on: [pull_request]
+
+jobs:
+  check-mix-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Elixir
+        uses: actions/setup-elixir@v1.2.0
+        with:
+          elixir-version: 1.9
+          otp-version: 22.2
+          runs-on: ubuntu-latest
+      - name: Git Stuff
+        id: git
+        run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/* 
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Check App versions
+        run: |
+          export MESSAGE=$(elixir -r scripts/version_differ.exs -e 'VersionDiffer.cli')
+          echo ::set-output name=pr_message::$MESSAGE
+        id: differ
+      - name: Comment PR
+        uses: marocchino/sticky-pull-request-comment@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            ${{ steps.differ.outputs.pr_message }}

--- a/scripts/version_differ.exs
+++ b/scripts/version_differ.exs
@@ -1,0 +1,81 @@
+defmodule VersionDiffer do
+  require Logger
+
+  def cli do
+    changed_apps = get_changed_apps()
+    changed_app_versions = get_app_versions(changed_apps)
+    tags = get_tags()
+
+    app_version_messages =
+      changed_app_versions
+      |> Enum.filter(&(&1 in tags))
+      |> Enum.map(&format_app/1)
+
+    case app_version_messages do
+      [] ->
+        IO.puts("Did not detect any app version problems")
+
+      apps ->
+        IO.puts("Tags already exist for #{Enum.join(apps, ", ")}. Please update each `apps/${app}/mix.exs` with a new version.")
+    end
+  end
+
+  defp format_app({app, vsn}) do
+    "`#{String.capitalize(app)} #{
+      Enum.join([vsn.major, vsn.minor, vsn.patch], ".")
+    }`"
+  end
+
+  def get_changed_apps do
+    with {raw, 0} <- get_raw_file_diff() do
+      extract_apps(raw)
+    else
+      error ->
+        Logger.error("Error getting file diff: (#{inspect(error)})")
+        []
+    end
+  end
+
+  def get_app_versions(apps) do
+    Application.ensure_all_started(:mix)
+
+    Enum.map(apps, &get_app_version/1)
+  end
+
+  def get_tags do
+    with {tags, 0} <- System.cmd("git", ["tag"]) do
+      tags
+      |> String.split("\n")
+      |> Enum.map(&String.split(&1, "@"))
+      |> Enum.reject(&(length(&1) != 2))
+      |> Enum.map(fn [app, vsn] -> {app, Version.parse!(vsn)} end)
+    else
+      {result, code} -> raise inspect({result, code})
+    end
+  end
+
+  defp get_app_version(app) do
+    with app_path = "apps/#{app}/mix.exs",
+         true <- File.exists?(app_path),
+         {{:module, module, _, _}, _} <- Code.eval_file(app_path) do
+      {app, module.project()[:version] |> Version.parse!()}
+    end
+  end
+
+  defp get_raw_file_diff do
+    System.cmd("git", ["diff", "--name-status", "origin/master"])
+  end
+
+  defp extract_apps(raw) do
+    raw
+    |> String.split(["\n", "\t"])
+    |> Enum.map(&String.split(&1, "/"))
+    |> Enum.map(fn
+      ["apps", app | _rest] -> app
+      _other -> []
+    end)
+    |> List.flatten()
+    |> MapSet.new()
+    |> MapSet.to_list()
+  end
+end


### PR DESCRIPTION
Compares the `mix.exs` version for each app with changes to existing tags and adds a comment for any that need to be updated

Example with version mismatch here: https://github.com/jakeprem/smartcitiesdata/pull/1#issuecomment-572753245