### PR TITLE
convert subschema maps to atom keys to fix xml validations on selector

### DIFF
--- a/apps/andi/lib/andi/input_schemas/input_converter.ex
+++ b/apps/andi/lib/andi/input_schemas/input_converter.ex
@@ -18,6 +18,7 @@ defmodule Andi.InputSchemas.InputConverter do
     %{id: id}
     |> Map.merge(from_business)
     |> Map.merge(from_technical)
+    |> AtomicMap.convert(safe: false, underscore: false)
     |> DatasetInput.full_validation_changeset()
   end
 

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "0.18.1",
+      version: "0.18.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
smartcitiesdata/migration#506

co-authored-by: Scott Millard <wannafly37@gmail.com>