### PR TITLE
place tighter controls around how a dataset is handled so we avoid re-ingesting old datasets

### DIFF
--- a/apps/reaper/lib/reaper/collections/base_dataset.ex
+++ b/apps/reaper/lib/reaper/collections/base_dataset.ex
@@ -31,11 +31,16 @@ defmodule Reaper.Collections.BaseDataset do
       end
 
       def is_enabled?(dataset_id) do
-        case Brook.get!(unquote(instance), unquote(collection), dataset_id) do
-          nil -> false
-          value -> Map.get(value, "enabled", true)
-        end
+        Brook.get!(unquote(instance), unquote(collection), dataset_id)
+        |> is_dataset_entry_enabled?()
       end
+
+      defp is_dataset_entry_enabled?(nil = _missing_dataset_entry), do: false
+
+      defp is_dataset_entry_enabled?(%{"dataset" => _} = dataset_entry_we_have_seen_an_update_for),
+        do: Map.get(dataset_entry_we_have_seen_an_update_for, "enabled", true)
+
+      defp is_dataset_entry_enabled?(incomplete_dataset_entry), do: Map.get(incomplete_dataset_entry, "enabled", false)
 
       def get_dataset!(id) do
         case Brook.get!(unquote(instance), unquote(collection), id) do
@@ -64,12 +69,15 @@ defmodule Reaper.Collections.BaseDataset do
         |> Enum.map(&Map.get(&1, "dataset"))
       end
 
-      defp should_start(%{"enabled" => true, "started_timestamp" => start_time, "last_fetched_timestamp" => end_time})
+      defp should_start(%{"started_timestamp" => start_time, "last_fetched_timestamp" => end_time} = dataset_entry)
            when not is_nil(start_time) and not is_nil(end_time) do
-        DateTime.compare(start_time, end_time) == :gt
+        is_dataset_entry_enabled?(dataset_entry) && DateTime.compare(start_time, end_time) == :gt
       end
 
-      defp should_start(%{"enabled" => true, "started_timestamp" => start_time}) when not is_nil(start_time), do: true
+      defp should_start(%{"started_timestamp" => start_time} = dataset_entry) when not is_nil(start_time) do
+        is_dataset_entry_enabled?(dataset_entry)
+      end
+
       defp should_start(_), do: false
     end
   end

--- a/apps/reaper/lib/reaper/collections/base_dataset.ex
+++ b/apps/reaper/lib/reaper/collections/base_dataset.ex
@@ -6,16 +6,18 @@ defmodule Reaper.Collections.BaseDataset do
     collection = Keyword.fetch!(opts, :collection)
 
     quote do
-      def update_dataset(%SmartCity.Dataset{} = dataset, start_time \\ DateTime.utc_now()) do
+      def update_dataset(%SmartCity.Dataset{} = dataset) do
         Brook.ViewState.merge(unquote(collection), dataset.id, %{
-          "dataset" => dataset,
-          "started_timestamp" => start_time,
-          "enabled" => true
+          "dataset" => dataset
         })
       end
 
       def update_last_fetched_timestamp(id, fetched_time \\ DateTime.utc_now()) do
         Brook.ViewState.merge(unquote(collection), id, %{"last_fetched_timestamp" => fetched_time})
+      end
+
+      def update_started_timestamp(id, started_time \\ DateTime.utc_now()) do
+        Brook.ViewState.merge(unquote(collection), id, %{"started_timestamp" => started_time})
       end
 
       def disable_dataset(dataset_id) do
@@ -31,7 +33,7 @@ defmodule Reaper.Collections.BaseDataset do
       def is_enabled?(dataset_id) do
         case Brook.get!(unquote(instance), unquote(collection), dataset_id) do
           nil -> false
-          value -> value["enabled"]
+          value -> Map.get(value, "enabled", true)
         end
       end
 
@@ -39,6 +41,13 @@ defmodule Reaper.Collections.BaseDataset do
         case Brook.get!(unquote(instance), unquote(collection), id) do
           nil -> nil
           value -> value["dataset"]
+        end
+      end
+
+      def get_started_timestamp!(dataset_id) do
+        case Brook.get!(unquote(instance), unquote(collection), dataset_id) do
+          nil -> nil
+          value -> Map.get(value, "started_timestamp", nil)
         end
       end
 

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "0.16.1",
+      version: "0.17.0",
       elixir: "~> 1.8",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/reaper/test/integration/reaper/reaper_full_test.exs
+++ b/apps/reaper/test/integration/reaper/reaper_full_test.exs
@@ -3,10 +3,22 @@ defmodule Reaper.FullTest do
   use Divo
   use Tesla
   use Placebo
+  import Checkov
+
   require Logger
   alias SmartCity.TestDataGenerator, as: TDG
   import SmartCity.TestHelper
-  import SmartCity.Event, only: [dataset_update: 0, dataset_delete: 0]
+
+  import SmartCity.Event,
+    only: [
+      dataset_update: 0,
+      dataset_disable: 0,
+      dataset_delete: 0,
+      data_extract_start: 0,
+      file_ingest_start: 0,
+      data_extract_end: 0,
+      file_ingest_end: 0
+    ]
 
   alias Reaper.Collections.Extractions
 
@@ -417,6 +429,155 @@ defmodule Reaper.FullTest do
         assert expected == last_one
       end)
     end
+  end
+
+  describe "#{dataset_disable()} then a #{dataset_update()}" do
+    setup %{bypass: bypass} do
+      dataset =
+        TDG.create_dataset(%{
+          technical: %{
+            cadence: "*/5 * * * * * *",
+            sourceUrl: "http://localhost:#{bypass.port}/#{@csv_file_name}",
+            sourceFormat: "csv",
+            sourceType: "stream",
+            schema: [%{name: "id"}, %{name: "name"}, %{name: "pet"}]
+          }
+        })
+
+      Brook.Event.send(@instance, dataset_update(), :reaper, dataset)
+
+      eventually(fn ->
+        assert %{state: :active} = Reaper.Scheduler.find_job(String.to_atom(dataset.id))
+        assert Reaper.Collections.Extractions.is_enabled?(dataset.id) == true
+      end)
+
+      Brook.Event.send(@instance, dataset_disable(), :reaper, dataset)
+
+      eventually(fn ->
+        assert %{state: :inactive} = Reaper.Scheduler.find_job(String.to_atom(dataset.id))
+        assert Reaper.Collections.Extractions.is_enabled?(dataset.id) == false
+      end)
+
+      [dataset: dataset]
+    end
+
+    test "sending an update for the disabled dataset does NOT re-enable it", %{dataset: dataset} do
+      Brook.Event.send(@instance, dataset_update(), :reaper, dataset)
+
+      Process.sleep(5_000)
+
+      eventually(fn ->
+        assert %{state: :inactive} = Reaper.Scheduler.find_job(String.to_atom(dataset.id))
+        assert Reaper.Collections.Extractions.is_enabled?(dataset.id) == false
+      end)
+    end
+  end
+
+  test "dataset:update updates dataset definition in view state", %{bypass: bypass} do
+    dataset =
+      TDG.create_dataset(%{
+        technical: %{
+          cadence: "once",
+          sourceUrl: "http://localhost:#{bypass.port}/#{@csv_file_name}",
+          sourceFormat: "csv",
+          sourceType: "ingest",
+          schema: [%{name: "id"}, %{name: "name"}, %{name: "pet"}]
+        }
+      })
+
+    Brook.Event.send(@instance, dataset_update(), :reaper, dataset)
+
+    eventually(fn ->
+      assert Reaper.Collections.Extractions.get_dataset!(dataset.id) == dataset
+    end)
+  end
+
+  data_test "extracts and ingests update started_timestamp in view state", %{bypass: bypass} do
+    dataset =
+      TDG.create_dataset(%{
+        technical: %{
+          cadence: "once",
+          sourceUrl: "http://localhost:#{bypass.port}/#{@csv_file_name}",
+          sourceFormat: "csv",
+          sourceType: source_type,
+          schema: [%{name: "id"}, %{name: "name"}, %{name: "pet"}]
+        }
+      })
+
+    Brook.Event.send(@instance, dataset_update(), :reaper, dataset)
+
+    eventually(fn ->
+      assert view_state_module.is_enabled?(dataset.id) == true
+    end)
+
+    Brook.Event.send(@instance, start_event_type, :reaper, dataset)
+
+    eventually(fn ->
+      assert nil != view_state_module.get_started_timestamp!(dataset.id)
+    end)
+
+    now = DateTime.utc_now()
+    Brook.Event.send(@instance, start_event_type, :reaper, dataset)
+
+    eventually(fn ->
+      assert DateTime.compare(view_state_module.get_started_timestamp!(dataset.id), now) == :gt
+    end)
+
+    where([
+      [:start_event_type, :source_type, :view_state_module],
+      [data_extract_start(), "ingest", Reaper.Collections.Extractions],
+      [file_ingest_start(), "host", Reaper.Collections.FileIngestions]
+    ])
+  end
+
+  data_test "dataset:disable followed by a ingest or extract start", %{bypass: bypass} do
+    dataset =
+      TDG.create_dataset(%{
+        technical: %{
+          cadence: "once",
+          sourceUrl: "http://localhost:#{bypass.port}/#{@csv_file_name}",
+          sourceFormat: "csv",
+          sourceType: source_type,
+          schema: [%{name: "id"}, %{name: "name"}, %{name: "pet"}]
+        }
+      })
+
+    Brook.Event.send(@instance, dataset_update(), :reaper, dataset)
+
+    eventually(fn ->
+      assert view_state_module.is_enabled?(dataset.id) == true
+    end)
+
+    Brook.Event.send(@instance, dataset_disable(), :reaper, dataset)
+
+    eventually(fn ->
+      assert view_state_module.is_enabled?(dataset.id) == false
+    end)
+
+    marked_dataset = TDG.create_dataset(Map.merge(dataset, %{business: %{dataTitle: "this-should-not-extract"}}))
+    Brook.Event.send(@instance, start_event_type, :reaper, marked_dataset)
+
+    Process.sleep(5_000)
+
+    eventually(fn ->
+      assert view_state_module.is_enabled?(dataset.id) == false
+      assert not (marked_dataset in fetch_event_messages_of_type(end_event_type))
+    end)
+
+    where([
+      [:start_event_type, :end_event_type, :source_type, :view_state_module],
+      [data_extract_start(), data_extract_end(), "ingest", Reaper.Collections.Extractions],
+      [file_ingest_start(), file_ingest_end(), "host", Reaper.Collections.FileIngestions]
+    ])
+  end
+
+  defp fetch_event_messages_of_type(type) do
+    Elsa.Fetch.search_keys([localhost: 9092], "event-stream", type)
+    |> Enum.to_list()
+    |> Enum.map(fn %Elsa.Message{value: value} ->
+      {:ok, data} = Jason.decode!(value)["data"] |> Brook.Deserializer.deserialize()
+      data
+    end)
   end
 
   test "should delete the dataset and the view state when delete event is called" do

--- a/apps/reaper/test/unit/reaper/collections/base_dataset_test.exs
+++ b/apps/reaper/test/unit/reaper/collections/base_dataset_test.exs
@@ -1,0 +1,75 @@
+defmodule Reaper.Collections.BaseDatasetTest do
+  use ExUnit.Case
+  use Placebo
+  require Logger
+
+  @instance Reaper.Application.instance()
+
+  alias Reaper.Collections.Extractions
+  alias SmartCity.TestDataGenerator, as: TDG
+
+  setup do
+    {:ok, brook} = Brook.start_link(Application.get_env(:reaper, :brook) |> Keyword.put(:instance, @instance))
+
+    Brook.Test.register(@instance)
+
+    on_exit(fn ->
+      kill(brook)
+    end)
+
+    :ok
+  end
+
+  describe "is_enabled?/1" do
+    test "a dataset that is not in the view state is not enabled" do
+      assert false == Extractions.is_enabled?("not-there?")
+    end
+
+    test "a dataset that has no definition in the view state is not enabled" do
+      id = "almost-there"
+
+      Brook.Test.with_event(@instance, fn ->
+        Extractions.update_started_timestamp(id)
+      end)
+
+      assert false == Extractions.is_enabled?(id)
+    end
+
+    test "a dataset that has no definition in the view state, but has its enabled flag explicitly set, reflects it" do
+      id = "explicitly-there"
+
+      Brook.Test.with_event(@instance, fn ->
+        Brook.ViewState.merge(:extractions, id, %{"enabled" => true})
+      end)
+
+      assert true == Extractions.is_enabled?(id)
+    end
+
+    test "a dataset that has a definition in the view state (via update), but has no enabled flag explicitly set IS enabled" do
+      dataset = TDG.create_dataset(%{})
+
+      Brook.Test.with_event(@instance, fn ->
+        Extractions.update_dataset(dataset)
+      end)
+
+      assert true == Extractions.is_enabled?(dataset.id)
+    end
+
+    test "a dataset that has a definition in the view state (via update), but has its enabled flag explicitly set, reflects that" do
+      dataset = TDG.create_dataset(%{})
+
+      Brook.Test.with_event(@instance, fn ->
+        Extractions.update_dataset(dataset)
+        Extractions.disable_dataset(dataset.id)
+      end)
+
+      assert false == Extractions.is_enabled?(dataset.id)
+    end
+  end
+
+  defp kill(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :normal)
+    assert_receive {:DOWN, ^ref, _, _, _}
+  end
+end

--- a/apps/reaper/test/unit/reaper/init_test.exs
+++ b/apps/reaper/test/unit/reaper/init_test.exs
@@ -32,6 +32,7 @@ defmodule Reaper.InitTest do
 
       Brook.Test.with_event(@instance, fn ->
         Extractions.update_dataset(dataset)
+        Extractions.update_started_timestamp(dataset.id)
         Extractions.update_last_fetched_timestamp(dataset.id, nil)
       end)
 
@@ -51,7 +52,8 @@ defmodule Reaper.InitTest do
       dataset = TDG.create_dataset(id: "ds1", technical: %{sourceType: "ingest"})
 
       Brook.Test.with_event(@instance, fn ->
-        Extractions.update_dataset(dataset, start_time)
+        Extractions.update_dataset(dataset)
+        Extractions.update_started_timestamp(dataset.id, start_time)
         Extractions.update_last_fetched_timestamp(dataset.id, end_time)
       end)
 
@@ -68,7 +70,8 @@ defmodule Reaper.InitTest do
       dataset = TDG.create_dataset(id: "ds1", technical: %{sourceType: "ingest"})
 
       Brook.Test.with_event(@instance, fn ->
-        Extractions.update_dataset(dataset, start_time)
+        Extractions.update_dataset(dataset)
+        Extractions.update_started_timestamp(dataset.id, start_time)
         Extractions.disable_dataset(dataset.id)
       end)
 
@@ -86,7 +89,8 @@ defmodule Reaper.InitTest do
       dataset = TDG.create_dataset(id: "ds1", technical: %{sourceType: "ingest"})
 
       Brook.Test.with_event(@instance, fn ->
-        Extractions.update_dataset(dataset, start_time)
+        Extractions.update_dataset(dataset)
+        Extractions.update_started_timestamp(dataset.id, start_time)
         Extractions.update_last_fetched_timestamp(dataset.id, end_time)
       end)
 
@@ -119,6 +123,7 @@ defmodule Reaper.InitTest do
 
       Brook.Test.with_event(@instance, fn ->
         FileIngestions.update_dataset(dataset)
+        FileIngestions.update_started_timestamp(dataset.id)
       end)
 
       Reaper.Init.run()
@@ -137,7 +142,8 @@ defmodule Reaper.InitTest do
       dataset = TDG.create_dataset(id: "ds1", technical: %{sourceType: "host"})
 
       Brook.Test.with_event(@instance, fn ->
-        FileIngestions.update_dataset(dataset, start_time)
+        FileIngestions.update_dataset(dataset)
+        FileIngestions.update_started_timestamp(dataset.id, start_time)
         FileIngestions.update_last_fetched_timestamp(dataset.id, end_time)
       end)
 
@@ -155,7 +161,8 @@ defmodule Reaper.InitTest do
       dataset = TDG.create_dataset(id: "ds1", technical: %{sourceType: "host"})
 
       Brook.Test.with_event(@instance, fn ->
-        FileIngestions.update_dataset(dataset, start_time)
+        FileIngestions.update_dataset(dataset)
+        FileIngestions.update_started_timestamp(dataset.id, start_time)
         FileIngestions.update_last_fetched_timestamp(dataset.id, end_time)
       end)
 


### PR DESCRIPTION
- extractions and ingestions are not triggered if a dataset has been explicitly disabled
- extractions and ingestions ONLY update the start timestamp for a dataset
- dataset update ONLY updates the dataset definition in view state
- datasets, if their definition is present in view state, are considered enabled until they are explicitly disabled

smartcitiesdata/smartcitiesdata#447

co-authored-by: Benjamin Brewer <benjamin.brewer@accenture.com>