### PR TITLE
quick fix to resolve a WDC issue

### DIFF
--- a/apps/discovery_api/lib/discovery_api/data/model.ex
+++ b/apps/discovery_api/lib/discovery_api/data/model.ex
@@ -158,16 +158,21 @@ defmodule DiscoveryApi.Data.Model do
   def pop(data, key), do: Map.pop(data, key)
 
   def to_table_info(model) do
-    columns_from_schema =
-      Enum.map(model.schema, fn schema ->
-        %{id: id_to_alphanumeric(schema.name), description: schema.name, dataType: schema.type}
-      end)
+    columns_from_schema = Enum.map(model.schema, &to_column_info/1)
 
     %{
       id: id_to_alphanumeric(model.id),
       description: model.id,
       alias: model.title,
       columns: columns_from_schema
+    }
+  end
+
+  defp to_column_info(schema_field) do
+    %{
+      id: id_to_alphanumeric(schema_field.name),
+      description: String.downcase(schema_field.name),
+      dataType: schema_field.type
     }
   end
 

--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "0.39.0",
+      version: "0.39.1",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/discovery_api/test/unit/discovery_api/data/model_test.exs
+++ b/apps/discovery_api/test/unit/discovery_api/data/model_test.exs
@@ -155,7 +155,7 @@ defmodule DiscoveryApi.Data.ModelTest do
       assert actual_columns == expected_columns
     end
 
-    test "converts mixed case schema fields" do
+    test "converts mixed case schema fields by converting to a safe id and downcasing the description" do
       model =
         Helper.sample_model(%{
           schema: [
@@ -169,7 +169,7 @@ defmodule DiscoveryApi.Data.ModelTest do
       expected_columns = [
         %{
           dataType: "string",
-          description: "bob-Field",
+          description: "bob-field",
           id: "bob_field"
         }
       ]


### PR DESCRIPTION
Our columns are downcased when they are returned as part of the data, and so we could not look up data using the mixed case column names in the schema itself which is where the table_info comes from. 

An old problem, but a consistent one.