### PR TITLE
Reaper provision expansion

### DIFF
--- a/apps/providers/lib/providers/timestamp.ex
+++ b/apps/providers/lib/providers/timestamp.ex
@@ -1,6 +1,11 @@
 defmodule Providers.Timestamp do
   @moduledoc """
   This provider implementation returns the current timestamp in UTC as an ISO8601 compliant date string.
+
+  Version 2 provides additional options:
+  + format: Timex compliant format for the result
+  + timezone: Timex compliant timezone. Full name is recommended for readability and DST compliance: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+  + offset_in_seconds: Time offset in seconds, positive for future times, negative for past times.
   """
   @behaviour Providers.Provider
 
@@ -8,4 +13,10 @@ defmodule Providers.Timestamp do
     NaiveDateTime.utc_now() |> NaiveDateTime.to_iso8601()
   end
 
+  def provide("2", opts) do
+    format = Map.get(opts, :format, "{ISO:Extended:Z}")
+    timezone = Map.get(opts, :timezone, :utc)
+    offset = Map.get(opts, :offset_in_seconds, 0)
+    Timex.now(timezone) |> Timex.shift(seconds: offset) |> Timex.format!(format)
+  end
 end

--- a/apps/providers/mix.exs
+++ b/apps/providers/mix.exs
@@ -28,7 +28,7 @@ defmodule Providers.MixProject do
     [
       {:mox, "~> 0.5.1", only: [:dev, :test, :integration]},
       {:credo, "~> 1.1", only: [:dev, :test, :integration], runtime: false},
-      {:timex, "~> 3.6"},
+      {:timex, "~> 3.6"}
     ]
   end
 

--- a/apps/providers/test/unit/providers/date_test.exs
+++ b/apps/providers/test/unit/providers/date_test.exs
@@ -23,7 +23,8 @@ defmodule Providers.DateTest do
 
       result = Providers.Date.provide("1", %{offset_in_days: offset_in_days})
 
-      assert offset_in_days >= Timex.diff(Timex.parse!(result, @default_format), Timex.now(), :day)
+      assert offset_in_days >=
+               Timex.diff(Timex.parse!(result, @default_format), Timex.now(), :day)
     end
 
     test "provides a date with offset applied before formatting" do
@@ -32,7 +33,9 @@ defmodule Providers.DateTest do
 
       result = Providers.Date.provide("1", %{format: format, offset_in_days: offset_in_days})
 
-      assert Timex.now() |> Timex.add(Timex.Duration.from_days(offset_in_days)) |> Timex.format!(format) == result
+      assert Timex.now()
+             |> Timex.add(Timex.Duration.from_days(offset_in_days))
+             |> Timex.format!(format) == result
     end
   end
 end

--- a/apps/providers/test/unit/providers/timestamp_test.exs
+++ b/apps/providers/test/unit/providers/timestamp_test.exs
@@ -9,4 +9,32 @@ defmodule Providers.TimestampTest do
     end
   end
 
+  describe "v2" do
+    test "provides a valid timestamp, defaulting to iso8601 format" do
+      timestamp = Providers.Timestamp.provide("2", %{})
+
+      assert {:ok, _timestamp} = NaiveDateTime.from_iso8601(timestamp)
+    end
+
+    test "provides a valid timestamp in the provided timex format" do
+      timestamp = Providers.Timestamp.provide("2", %{format: "{ISOtime}"})
+
+      assert {:ok, _timestamp} = Timex.parse(timestamp, "{ISOtime}")
+    end
+
+    test "provides a valid timestamp in the provided timezone" do
+      timestamp = Providers.Timestamp.provide("2", %{format: "{ISO:Basic}", timezone: "Asia/Ulaanbaatar"})
+
+      assert String.contains?(timestamp, "+0800")
+    end
+
+    test "provides a valid timestamp offset by seconds" do
+      format = "{YYYY}-{0M}-{0D}"
+      offset_in_days = -1
+      timestamp = Providers.Timestamp.provide("2", %{offset_in_seconds: offset_in_days * 24 * 60 * 60, format: format})
+
+      assert Timex.now() |> Timex.add(Timex.Duration.from_days(offset_in_days)) |> Timex.format!(format) == timestamp
+    end
+  end
+
 end

--- a/apps/providers/test/unit/providers/timestamp_test.exs
+++ b/apps/providers/test/unit/providers/timestamp_test.exs
@@ -23,7 +23,10 @@ defmodule Providers.TimestampTest do
     end
 
     test "provides a valid timestamp in the provided timezone" do
-      timestamp = Providers.Timestamp.provide("2", %{format: "{ISO:Basic}", timezone: "Asia/Ulaanbaatar"})
+      timestamp = Providers.Timestamp.provide(
+        "2",
+        %{format: "{ISO:Basic}", timezone: "Asia/Ulaanbaatar"}
+      )
 
       assert String.contains?(timestamp, "+0800")
     end
@@ -31,10 +34,16 @@ defmodule Providers.TimestampTest do
     test "provides a valid timestamp offset by seconds" do
       format = "{YYYY}-{0M}-{0D}"
       offset_in_days = -1
-      timestamp = Providers.Timestamp.provide("2", %{offset_in_seconds: offset_in_days * 24 * 60 * 60, format: format})
 
-      assert Timex.now() |> Timex.add(Timex.Duration.from_days(offset_in_days)) |> Timex.format!(format) == timestamp
+      timestamp =
+        Providers.Timestamp.provide("2", %{
+          offset_in_seconds: offset_in_days * 24 * 60 * 60,
+          format: format
+        })
+
+      assert Timex.now()
+             |> Timex.add(Timex.Duration.from_days(offset_in_days))
+             |> Timex.format!(format) == timestamp
     end
   end
-
 end

--- a/apps/reaper/lib/reaper/data_extract/load_stage.ex
+++ b/apps/reaper/lib/reaper/data_extract/load_stage.ex
@@ -115,7 +115,9 @@ defmodule Reaper.DataExtract.LoadStage do
         start = format_date(state.start_time)
         stop = format_date(DateTime.utc_now())
         [%{app: "reaper", label: "Ingested", start_time: start, end_time: stop}]
-      _ -> []
+
+      _ ->
+        []
     end
   end
 

--- a/apps/reaper/mix.exs
+++ b/apps/reaper/mix.exs
@@ -4,7 +4,7 @@ defmodule Reaper.MixProject do
   def project do
     [
       app: :reaper,
-      version: "0.18.0",
+      version: "0.19.0",
       elixir: "~> 1.8",
       build_path: "../../_build",
       config_path: "../../config/config.exs",

--- a/apps/reaper/test/unit/reaper/data_extract/processor_test.exs
+++ b/apps/reaper/test/unit/reaper/data_extract/processor_test.exs
@@ -142,7 +142,7 @@ defmodule Reaper.DataExtract.ProcessorTest do
     allow Persistence.record_last_processed_index(dataset_id, any()), return: "OK"
 
     Providers.Echo
-    |> expect(:provide, fn _, %{value: value} -> value end)
+    |> expect(:provide, 2, fn _, %{value: value} -> value end)
 
     provisioned_dataset =
       TDG.create_dataset(
@@ -150,7 +150,11 @@ defmodule Reaper.DataExtract.ProcessorTest do
         technical: %{
           sourceType: "ingest",
           sourceFormat: "csv",
-          sourceUrl: "http://localhost:#{bypass.port}/api/csv",
+          sourceUrl: %{
+            provider: "Echo",
+            opts: %{value: "http://localhost:#{bypass.port}/api/csv"},
+            version: "1"
+          },
           cadence: 100,
           schema: [
             %{name: "a", type: "string"},

--- a/apps/reaper/test/unit/reaper/data_slurper/s3_test.exs
+++ b/apps/reaper/test/unit/reaper/data_slurper/s3_test.exs
@@ -26,7 +26,9 @@ defmodule Reaper.DataSlurper.S3Test do
       dataset_id = "12345-6789"
       filename = "#{@download_dir}#{dataset_id}"
 
-      assert {:file, filename} == Reaper.DataSlurper.S3.slurp(source_url, dataset_id, %{"x-scos-amzn-s3-region": "us-east-1"})
+      assert {:file, filename} ==
+               Reaper.DataSlurper.S3.slurp(source_url, dataset_id, %{"x-scos-amzn-s3-region": "us-east-1"})
+
       assert_called ExAws.request(any(), region: "us-east-1")
       refute_called ExAws.request(any(), [])
     end

--- a/apps/reaper/test/unit/reaper/file_ingest/processor_test.exs
+++ b/apps/reaper/test/unit/reaper/file_ingest/processor_test.exs
@@ -23,26 +23,66 @@ defmodule Reaper.FileIngest.ProcessorTest do
     Providers.Echo
     |> expect(:provide, 1, fn _, %{value: value} -> value end)
 
-    dataset =
-      TDG.create_dataset(
-        id: @dataset_id,
-        technical: %{
-          sourceType: "host",
-          sourceFormat: "txt",
-          sourceUrl: %{
-            provider: "Echo",
-            opts: %{value: @source_url},
-            version: "1"
-          },
-          cadence: 100
-        }
-      )
-
-    [dataset: dataset]
+    :ok
   end
 
   describe "process/1 happy path" do
-    test "downloads file and uploads to s3 with provisioned url", %{dataset: dataset} do
+    test "downloads file and uploads to s3" do
+      dataset =
+        TDG.create_dataset(
+          id: @dataset_id,
+          technical: %{
+            sourceType: "host",
+            sourceFormat: "txt",
+            sourceUrl: @source_url,
+            cadence: 100
+          }
+        )
+
+      expect(Reaper.DataSlurper.slurp(@source_url, dataset.id, any(), any()),
+        meck_options: [:passthrough],
+        return: {:file, "filename"}
+      )
+
+      expect(
+        ExAws.S3.upload(
+          any(),
+          any(),
+          "#{dataset.technical.orgName}/#{dataset.technical.dataName}.txt"
+        ),
+        meck_options: [:passthrough]
+      )
+
+      expect(Brook.Event.send(any(), any(), any(), any()), return: :ok)
+
+      Processor.process(dataset)
+
+      expected_file_upload = %HostedFile{
+        dataset_id: dataset.id,
+        mime_type: "text/plain",
+        bucket: @bucket,
+        key: "#{dataset.technical.orgName}/#{dataset.technical.dataName}.txt"
+      }
+
+      assert_called(Brook.Event.send(@instance, file_ingest_end(), :reaper, expected_file_upload))
+    end
+
+    test "downloads file with a provisioned url and uploads to s3" do
+      dataset =
+        TDG.create_dataset(
+          id: @dataset_id,
+          technical: %{
+            sourceType: "host",
+            sourceFormat: "txt",
+            sourceUrl: %{
+              provider: "Echo",
+              opts: %{value: @source_url},
+              version: "1"
+            },
+            cadence: 100
+          }
+        )
+
       expect(Reaper.DataSlurper.slurp(@source_url, dataset.id, any(), any()),
         meck_options: [:passthrough],
         return: {:file, "filename"}


### PR DESCRIPTION
+ This is in support of a data ingest card
+ Extends the timestamp provider with a version 2 that takes format, offset, and timezone
+ Allows hosted file ingestions to use providers. (This was not required for the card but it will save us from ourselves later)