### PR TITLE
more buckets

### DIFF
--- a/apps/discovery_api/lib/discovery_api/search/dataset_index.ex
+++ b/apps/discovery_api/lib/discovery_api/search/dataset_index.ex
@@ -277,8 +277,8 @@ defmodule DiscoveryApi.Search.DatasetIndex do
   defp search_query(search_opts) do
     %{
       "aggs" => %{
-        "keywords" => %{"terms" => %{"field" => "facets.keywords"}},
-        "organization" => %{"terms" => %{"field" => "facets.orgTitle"}}
+        "keywords" => %{"terms" => %{"field" => "facets.keywords", "size" => "2147483647"}},
+        "organization" => %{"terms" => %{"field" => "facets.orgTitle", "size" => "2147483647"}}
       },
       "from" => 0,
       "query" => %{

--- a/apps/discovery_api/lib/discovery_api/search/dataset_index.ex
+++ b/apps/discovery_api/lib/discovery_api/search/dataset_index.ex
@@ -4,6 +4,8 @@ defmodule DiscoveryApi.Search.DatasetIndex do
   """
   alias DiscoveryApi.Data.Model
 
+  @elasticsearch_max_buckets 2147483647
+
   def create_index() do
     %{name: name, options: options} = dataset_index()
     create_index(name, options)
@@ -277,8 +279,8 @@ defmodule DiscoveryApi.Search.DatasetIndex do
   defp search_query(search_opts) do
     %{
       "aggs" => %{
-        "keywords" => %{"terms" => %{"field" => "facets.keywords", "size" => "2147483647"}},
-        "organization" => %{"terms" => %{"field" => "facets.orgTitle", "size" => "2147483647"}}
+        "keywords" => %{"terms" => %{"field" => "facets.keywords", "size" => @elasticsearch_max_buckets}},
+        "organization" => %{"terms" => %{"field" => "facets.orgTitle", "size" => @elasticsearch_max_buckets}}
       },
       "from" => 0,
       "query" => %{

--- a/apps/discovery_api/lib/discovery_api/search/dataset_index.ex
+++ b/apps/discovery_api/lib/discovery_api/search/dataset_index.ex
@@ -4,7 +4,7 @@ defmodule DiscoveryApi.Search.DatasetIndex do
   """
   alias DiscoveryApi.Data.Model
 
-  @elasticsearch_max_buckets 2147483647
+  @elasticsearch_max_buckets 2_147_483_647
 
   def create_index() do
     %{name: name, options: options} = dataset_index()

--- a/apps/discovery_api/mix.exs
+++ b/apps/discovery_api/mix.exs
@@ -5,7 +5,7 @@ defmodule DiscoveryApi.Mixfile do
     [
       app: :discovery_api,
       compilers: [:phoenix, :gettext | Mix.compilers()],
-      version: "0.42.1",
+      version: "0.42.2",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
Elasticsearch defaults aggs to a max of 10 buckets. I've set it to the maximum allowed for now.