### PR TITLE
Removed default browser dialog for unsaved changes

### DIFF
--- a/apps/andi/assets/js/app.js
+++ b/apps/andi/assets/js/app.js
@@ -29,20 +29,6 @@ Hooks.showSnackbar = {
     }
 }
 
-Hooks.Unload = {
-    unSavedModalDisplayed() {
-        return this.el.dataset.showUnsavedChangesModal == "true";
-    },
-    mounted() {
-        window.addEventListener("beforeunload", e => {
-            if (!this.unSavedModalDisplayed()) {
-                e.preventDefault();
-                e.returnValue = '';
-            }
-        })
-    }
-}
-
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content");
 let liveSocket = new LiveSocket('/live', Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}})
 liveSocket.connect()

--- a/apps/andi/lib/andi_web/live/edit_live_view.ex
+++ b/apps/andi/lib/andi_web/live/edit_live_view.ex
@@ -18,7 +18,7 @@ defmodule AndiWeb.EditLiveView do
 
     ~L"""
     <div class="edit-page" id="dataset-edit-page">
-      <%= f = form_for @changeset, "#", [phx_change: :validate, phx_submit: :save, as: :form_data, phx_hook: "Unload", data: [show_unsaved_changes_modal: @show_unsaved_changes_modal]] %>
+      <%= f = form_for @changeset, "#", [phx_change: :validate, phx_submit: :save, as: :form_data] %>
         <% [business] = inputs_for(f, :business) %>
         <% [technical] = inputs_for(f, :technical) %>
         <%= hidden_input(f, :id) %>


### PR DESCRIPTION
Is a flaky solution to the unsaved changes dialog when navigating using the browser. Removing this for now.