### PR TITLE
Schema order fix

### DIFF
--- a/apps/andi/lib/andi/input_schemas/datasets/data_dictionary.ex
+++ b/apps/andi/lib/andi/input_schemas/datasets/data_dictionary.ex
@@ -21,6 +21,7 @@ defmodule Andi.InputSchemas.Datasets.DataDictionary do
     field(:rationale, :string)
     field(:bread_crumb, :string)
     field(:format, :string)
+    field(:sequence, :integer, read_after_writes: true)
     has_many(:subSchema, __MODULE__, foreign_key: :parent_id, on_replace: :delete)
 
     belongs_to(:data_dictionary, __MODULE__, type: Ecto.UUID, foreign_key: :parent_id)
@@ -46,7 +47,8 @@ defmodule Andi.InputSchemas.Datasets.DataDictionary do
     :technical_id,
     :parent_id,
     :bread_crumb,
-    :format
+    :format,
+    :sequence
   ]
   @required_fields [
     :name,

--- a/apps/andi/lib/andi/input_schemas/struct_tools.ex
+++ b/apps/andi/lib/andi/input_schemas/struct_tools.ex
@@ -30,7 +30,7 @@ defmodule Andi.InputSchemas.StructTools do
   def preload(nil, _fields), do: nil
 
   def preload(list, fields) when is_list(list) do
-    Enum.map(list, &preload(&1, fields))
+    Enum.map(list, &preload(&1, fields)) |> sort_if_sequenced()
   end
 
   def preload(%struct_type{} = struct, fields) do
@@ -70,6 +70,12 @@ defmodule Andi.InputSchemas.StructTools do
 
     struct(struct_type, preloaded)
   end
+
+  defp sort_if_sequenced([%{sequence: _sequence} | _] = list) do
+    Enum.sort(list, fn %{sequence: sequence1}, %{sequence: sequence2} -> sequence1 < sequence2 end)
+  end
+
+  defp sort_if_sequenced(list), do: list
 
   def struct_to_map(struct) do
     waste_fields = [:__meta__]

--- a/apps/andi/lib/andi/input_schemas/struct_tools.ex
+++ b/apps/andi/lib/andi/input_schemas/struct_tools.ex
@@ -72,7 +72,7 @@ defmodule Andi.InputSchemas.StructTools do
   end
 
   defp sort_if_sequenced([%{sequence: _sequence} | _] = list) do
-    Enum.sort(list, fn %{sequence: sequence1}, %{sequence: sequence2} -> sequence1 < sequence2 end)
+    Enum.sort_by(list, &Map.get(&1, :sequence))
   end
 
   defp sort_if_sequenced(list), do: list

--- a/apps/andi/mix.exs
+++ b/apps/andi/mix.exs
@@ -4,7 +4,7 @@ defmodule Andi.MixProject do
   def project do
     [
       app: :andi,
-      version: "0.29.6",
+      version: "0.30.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/apps/andi/priv/repo/migrations/20200709175229_add_sequence.exs
+++ b/apps/andi/priv/repo/migrations/20200709175229_add_sequence.exs
@@ -1,0 +1,10 @@
+defmodule Andi.Repo.Migrations.AddSequence do
+  use Ecto.Migration
+
+  def change do
+    alter table(:data_dictionary) do
+      add :sequence, :serial
+    end
+    execute "select setval(pg_get_serial_sequence('data_dictionary', 'sequence'), 1)"
+  end
+end

--- a/apps/andi/test/integration/andi_web/live/edit_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/edit_live_view_test.exs
@@ -710,14 +710,29 @@ defmodule AndiWeb.EditLiveViewTest do
 
       assert {:ok, view, html} = live(conn, @url_path <> dataset.id)
 
-      form_data = FormTools.form_data_from_andi_dataset(andi_dataset) |> put_in([:business, :dataTitle], "")
+      schema = andi_dataset.technical.schema |> Enum.map(fn
+        %{name: "my_date"} = field -> Map.put(field, :description, "desc") |> IO.inspect()
+        %{name: "my_float"} = field -> Map.put(field, :sequence, nil) |> IO.inspect()
+        %{name: "my_string"} = field -> Map.delete(field, :sequence) |> IO.inspect()
+        field -> field
+      end)
+
+      updated_dataset = put_in(andi_dataset, [:technical, :schema], schema)
+      {:ok, manually_updated_dataset} = Datasets.update(updated_dataset)
+      original_schema_order = dataset.technical.schema |> Enum.map(fn %{name: name} -> name end) |> Enum.join(",")
+
+      form_data = FormTools.form_data_from_andi_dataset(updated_dataset) |> put_in([:business, :dataTitle], "")
       form_data_changeset = InputConverter.form_data_to_full_changeset(%Dataset{}, form_data)
 
       render_change(view, :validate, %{"form_data" => form_data})
       html = render_change(view, :save, %{"form_data" => form_data})
 
+      changed_dataset = Datasets.get(dataset.id)
+      changed_schema_order = changed_dataset |> get_in([:technical, :schema]) |> Enum.map(fn %{name: name} -> name end) |> Enum.join(",")
+
       refute form_data_changeset.valid?
-      assert Datasets.get(dataset.id) |> get_in([:business, :dataTitle]) == ""
+      assert changed_dataset |> get_in([:business, :dataTitle]) == ""
+      assert original_schema_order == changed_schema_order
       assert get_text(html, "#form_data_business_dataTitle") == ""
       refute Enum.empty?(find_elements(html, "#dataTitle-error-msg"))
     end

--- a/apps/andi/test/integration/andi_web/live/edit_live_view_test.exs
+++ b/apps/andi/test/integration/andi_web/live/edit_live_view_test.exs
@@ -728,12 +728,14 @@ defmodule AndiWeb.EditLiveViewTest do
 
       assert {:ok, view, html} = live(conn, @url_path <> dataset.id)
 
-      schema = andi_dataset.technical.schema |> Enum.map(fn
-        %{name: "my_date"} = field -> Map.put(field, :description, "desc") |> IO.inspect()
-        %{name: "my_int"} = field -> Map.put(field, :sequence, "100000") |> IO.inspect()
-        %{name: "my_string"} = field -> Map.delete(field, :sequence) |> IO.inspect()
-        field -> field
-      end)
+      schema =
+        andi_dataset.technical.schema
+        |> Enum.map(fn
+          %{name: "my_date"} = field -> Map.put(field, :description, "desc")
+          %{name: "my_int"} = field -> Map.put(field, :sequence, "100000")
+          %{name: "my_string"} = field -> Map.delete(field, :sequence)
+          field -> field
+        end)
 
       updated_dataset = put_in(andi_dataset, [:technical, :schema], schema)
       {:ok, manually_updated_dataset} = Datasets.update(updated_dataset)
@@ -749,7 +751,7 @@ defmodule AndiWeb.EditLiveViewTest do
       changed_schema_order = changed_dataset |> get_in([:technical, :schema]) |> Enum.map(fn %{name: name} -> name end) |> Enum.join(",")
 
       assert changed_dataset |> get_in([:business, :dataTitle]) == ""
-      assert "my_string,my_date,my_float,my_boolean,my_int" == changed_schema_order
+      assert changed_schema_order == "my_string,my_date,my_float,my_boolean,my_int"
     end
   end
 


### PR DESCRIPTION
These changes create a field to track the order of fields in a schema. They are autogenerated as an increasing integer whenever the schema is edited.

The sequence field itself is editable, so we can easily use it to implement a reordering flow on the ui in the future if needed.